### PR TITLE
expose getPdfiumCoreConfig method to customize the config for subclass

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -311,8 +311,15 @@ public class PDFView extends RelativeLayout {
         debugPaint = new Paint();
         debugPaint.setStyle(Style.STROKE);
 
-        pdfiumCore = new PdfiumCore(context, new Config());
+        pdfiumCore = new PdfiumCore(context, this.getPdfiumCoreConfig());
         setWillNotDraw(false);
+    }
+
+    /**
+     * Method to be override to customize pdfiumCore's config for subclass
+     */
+    protected Config getPdfiumCoreConfig() {
+        return new Config();
     }
 
     private void load(DocumentSource docSource, String password) {


### PR DESCRIPTION
Currently there is no way for subclasses configure PdfiumCore's config. So I added those changes to make it happens

Usage
```java
public class SubClass extends PDFView {
    @Override
    protected Config getPdfiumCoreConfig() {
        return new Config(new DefaultLogger(), AlreadyClosedBehavior.IGNORE);
    }
}
```