### PR TITLE
upgrade io.legere:pdfiumandroid to 1.0.33

### DIFF
--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -13,5 +13,5 @@ android {
 
 dependencies {
     implementation 'androidx.core:core:1.12.0'
-    api 'io.legere:pdfiumandroid:1.0.19'
+    api 'io.legere:pdfiumandroid:1.0.33'
 }


### PR DESCRIPTION
Fixed the crash issue in io.legere:pdfiumandroid that occurred due to multithreading.
Therefore, we need to upgrade the io.legere:pdfiumandroid library to version 1.0.33.

https://github.com/johngray1965/PdfiumAndroidKt/pull/36