### PR TITLE
Update listener interfaces to `fun interfaces`

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnDrawListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnDrawListener.kt
@@ -24,7 +24,7 @@ import android.graphics.Canvas
  * This interface allows an extern class to draw
  * something on the PDFView canvas, above all images.
  */
-interface OnDrawListener {
+fun interface OnDrawListener {
     /**
      * This method is called when the PDFView is
      * drawing its view.

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnErrorListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnErrorListener.kt
@@ -18,7 +18,7 @@
  */
 package com.github.barteksc.pdfviewer.listener
 
-interface OnErrorListener {
+fun interface OnErrorListener {
     /**
      * Called if error occurred while opening PDF
      * @param t Throwable with error

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnLoadCompleteListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnLoadCompleteListener.kt
@@ -22,7 +22,7 @@ package com.github.barteksc.pdfviewer.listener
  * Implement this interface to receive events from PDFView
  * when loading is complete.
  */
-interface OnLoadCompleteListener {
+fun interface OnLoadCompleteListener {
     /**
      * Called when the PDF is loaded
      * @param nbPages the number of pages in this PDF file

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnLongPressListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnLongPressListener.kt
@@ -24,7 +24,7 @@ import android.view.MotionEvent
  * Implement this interface to receive events from PDFView
  * when view has been long pressed
  */
-interface OnLongPressListener {
+fun interface OnLongPressListener {
     /**
      * Called when the user has a long tap gesture, before processing scroll handle toggling
      *

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnPageChangeListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnPageChangeListener.kt
@@ -22,7 +22,7 @@ package com.github.barteksc.pdfviewer.listener
  * Implements this interface to receive events from PDFView
  * when a page has changed through swipe
  */
-interface OnPageChangeListener {
+fun interface OnPageChangeListener {
     /**
      * Called when the user use swipe to change page
      *

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnPageErrorListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnPageErrorListener.kt
@@ -18,7 +18,7 @@
  */
 package com.github.barteksc.pdfviewer.listener
 
-interface OnPageErrorListener {
+fun interface OnPageErrorListener {
     /**
      * Called if error occurred while loading PDF page
      * @param t Throwable with error

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnPageScrollListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnPageScrollListener.kt
@@ -22,7 +22,7 @@ package com.github.barteksc.pdfviewer.listener
  * Implements this interface to receive events from PDFView
  * when a page has been scrolled
  */
-interface OnPageScrollListener {
+fun interface OnPageScrollListener {
     /**
      * Called on every move while scrolling
      *

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnRenderListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnRenderListener.kt
@@ -18,7 +18,7 @@
  */
 package com.github.barteksc.pdfviewer.listener
 
-interface OnRenderListener {
+fun interface OnRenderListener {
     /**
      * Called only once, when document is rendered
      * @param nbPages number of pages

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnTapListener.kt
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnTapListener.kt
@@ -24,7 +24,7 @@ import android.view.MotionEvent
  * Implement this interface to receive events from PDFView
  * when view has been touched
  */
-interface OnTapListener {
+fun interface OnTapListener {
     /**
      * Called when the user has a tap gesture, before processing scroll handle toggling
      *


### PR DESCRIPTION
First of all, thank you @zacharee for maintaining this fork and doing the work on migrating the package to Kotlin! I came across your fork through [wonday/react-native-pdf](https://github.com/wonday/react-native-pdf).

### What?

Update all single-method listener interfaces to be Kotlin functional interfaces (SAM).

### Why?

Currently, all interfaces, e.g. `OnLoadCompleteListener` is a standard Kotlin interface. This prevents consumers from using lambda syntax when setting the listener, resulting in the following compile-time error:

```
    Argument type mismatch: actual type is 'Function1<...>', but 'OnLoadCompleteListener?' was expected.
```

<img width="845" height="208" alt="Screenshot 2026-01-05 at 14 28 52" src="https://github.com/user-attachments/assets/27f9c56e-b082-4e98-8bdd-c8bd94b28171" />

Users are currently always forced to implement the interface onto their class and do `.onLoad(this)`.

### How?

- [x] Add the `fun` keyword to all interfaces: 
	- This enables the idiomatic Kotlin lambda syntax while maintaining full backward compatibility for existing implementations and Java callers.
	- This means you can now do stuff like: `pdfView.onLoad { Log.d("Load", it) }`

### Remarks

Previously, when the original library was written in Java this worked out of the box with the geenrated Java-to-Kotlin interfaces that Android Studio did for us. Now that we've moved the files to Kotlin, we just need to be explicit about it as done in this PR :)